### PR TITLE
COM-10931: Precisions for statuses (names, groups, order, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ of a new main, the one with feature1-reviewing merged.
 
 
 ## Configuration file
+
+You create and periodically update this file by hand.
+(Possibly, in the future, we can create integration plugins for GitHub and GitLab for updating statuses automatically.)
+
 ```TOML
 [[remotes]]
 name = "origin"
@@ -112,19 +116,25 @@ Each feature has the following key/value pairs:
 : The URL used for the merge-request/pull-request
 
 `status`
-: This defines how `guw` should handle the `sync` process. In case of `pending`, this branch is still not
-requested to be integrated on the upstream project. In case of `merging`, the branch has already opened a
-merge-request/pull-request and is waiting for the community to be reviewed. In case of `merged`, the branch
-has already being merged but the other features depending on this have not being rebased yet. In case of
-`integrated`, the dependant features have been rebased already and the actual feature is no longer considered
-in any process.
+: This defines how `guw` should handle the `sync` process.
+Features with the same status compose groups in a strict order:
+
+1. `integrated` - already integrated, nothing to do;
+the dependant features have been rebased already and the actual feature is no longer considered in any process.
+1. `merged` - already merged, nothing to do;
+the branch has already being merged but the other features depending on this have not being rebased yet.
+1. `merging`, the branch has already opened a merge-request/pull-request
+and is waiting for the community to be reviewed
+1. `pending`, this branch is still not requested to be integrated on the upstream project.
+
+You cannot mix these groups.
 
 ## Usage
 First you need to install the package
 ```
 pip install git+https://github.com/fluendo/git-upstream-workflow.git
 ```
-After that, you will the command `guw`, with several options, the most used one is to sync branches based on
+After that, you will have the command `guw`, with several options, the most used one is to sync branches based on
 a configuration, simply do:
 ```
 guw -l debug example1.toml sync -l -b

--- a/guw/main.py
+++ b/guw/main.py
@@ -58,7 +58,7 @@ class GUW:
             if feature["status"] == "integrated":
                 if has_pending:
                     logger.critical(f"Feature {feature['name']} marked as integrated but after a pending feature")
-                    break
+                    return
                 logger.debug(f"Feature {feature['name']} already integrated, nothing to do")
             elif feature["status"] == "merged":
                 # When a feature (feature1) is merged, we don't really know what commits went upstream
@@ -80,6 +80,9 @@ class GUW:
                 to_push.append((feature["name"], feature["remote"]))
                 prev_active_feature = feature
                 has_pending = True
+            else:
+                logger.critical(f"Feature {feature['name']} has unknown status: '{feature['status']}'")
+                return
             prev_feature = feature
         # Make target branch be the last feature
         last_feature = self.config["features"][-1]

--- a/guw/main.py
+++ b/guw/main.py
@@ -88,16 +88,17 @@ class GUW:
         last_feature = self.config["features"][-1]
         if last_feature:
             if last_feature["status"] != "integrated":
-                target_branch = f"{self.config['target']['remote']}/{self.config['target']['branch']}"
+                target_branch_name = self.config['target']['branch']
                 last_feature_branch = f"{last_feature['remote']}/{last_feature['name']}"
-                repo.git.checkout("-b", self.config["target"]["branch"], last_feature_branch)
+                logger.info(f"Making target branch {target_branch_name} based on {last_feature_branch}")
+                repo.git.checkout("-b", target_branch_name, last_feature_branch)
                 if backup:
-                    feature_backup_name = self._backup_name(self.config['target']['branch'])
+                    feature_backup_name = self._backup_name(target_branch_name)
                     logger.debug(f"Backing up target branch into {feature_backup_name}")
                     repo.git.branch("-c", feature_backup_name)
                     to_push.append((feature_backup_name, self.config["target"]["remote"]))
                 repo.git.reset("--hard", last_feature["name"])
-                to_push.append((self.config["target"]["branch"], self.config["target"]["remote"]))
+                to_push.append((target_branch_name, self.config["target"]["remote"]))
             else:
                 logger.info("All features already integrated, nothing to do")
         # Push every branch

--- a/guw/main.py
+++ b/guw/main.py
@@ -194,3 +194,6 @@ def run():
             guw.sync(args.backup, args.keep, args.local)
         elif args.command == "markdown":
             guw.markdown()
+
+if __name__ == '__main__':
+    run()

--- a/guw/main.py
+++ b/guw/main.py
@@ -107,8 +107,8 @@ class GUW:
                 repo.git.push("-f", remote, branch)
         # TODO generate a new .toml for features from merged to integrated
 
-    def sync(self, backup, keep, local):
-        tmpdir = tempfile.mkdtemp()
+    def sync(self, backup, keep, local, folder):
+        tmpdir = folder if folder else tempfile.mkdtemp()
         exception = None
         try:
             self._sync_at(tmpdir, backup, local)
@@ -176,8 +176,9 @@ def run():
     # Sync subcommand
     sync_args = subparser.add_parser("sync", help="Sync the list of branches based on the configuration")
     sync_args.add_argument("-b", "--backup", help="Generate backup branches", action="store_true")
-    sync_args.add_argument("-k", "--keep", help="Keep temporary folder", action="store_true")
+    sync_args.add_argument("-k", "--keep", help="Keep working folder", action="store_true")
     sync_args.add_argument("-l", "--local", help="Don't push anything, but keep everything local", action="store_true")
+    sync_args.add_argument("-d", "--folder", help="Working folder, otherwise a new temporary folder is used.", default=None)
     # Markdown subcommand
     markdown_args = subparser.add_parser("markdown", help="Create a markdown content")
 
@@ -191,7 +192,7 @@ def run():
         config = tomli.load(fconfig)
         guw = GUW(config)
         if args.command == "sync":
-            guw.sync(args.backup, args.keep, args.local)
+            guw.sync(args.backup, args.keep, args.local, args.folder)
         elif args.command == "markdown":
             guw.markdown()
 


### PR DESCRIPTION
If I understand correctly, we have groups of statuses in strict order, and it is impossible to mix these groups up (for example, the usage of `has_pending` in the features cycle of the sync command).

Questions based on the existing algorithm in `GUW._sync_at()`:
1. `integrated` cannot appear between `merging` и `pending` (protected by `has_pending`); but what about `merged`, why there is no check for this?
1. Can we mix up `merging` и `pending` - there is no protection, there is no difference in treating them at all (it looks like, the only difference is to have the pr field or not).
1. `merging` could be multiple? Or just one at time?
1. What is the difference between `prev_feature` and `prev_active_feature`?

If so, we should change the algo; this is not an appropriate approach in `GUW._sync_at()`:
```Python
    for i in features:
        if i.status == integrated:
        elif i.status == merged:
        elif i.status == merging or pending:
        else # wrong name; I've added this in the PR
```
to
1. get group indexes using finding first in features (find first `integrated`, then first `merged`, and so on)
1. check indexes
    1. `integrated` - if any, comes first
    1. `merged` - if any, comes second
    1. `merging` - if any, comes third (and logically could be only one?)
    1. `pending`  - final group
1. ignore `integrated` and `merged`, only reporting, taking the latest as a base for rebase
1. rebasing `merging` and `pending`
 
Maybe we can change the syntax of the config file, as well, to have only three groups inside features (if my assumption on the difference between `merging` and `pending` is right).
```TOML
# remotes, target, source stuff as is

[[features.integrated]]
remote = "origin"
name = "feature1"
pr = "https://github/fluendo/git-upstream-workflow/pull-requests/XXX"

[[features.integrated]]
remote = "origin"
name = "another already integrated feature"
pr = "https://github/fluendo/git-upstream-workflow/pull-requests/XXX"

[[features.merged]]
remote = "origin"
name = "feature2"
pr = "https://github/fluendo/git-upstream-workflow/pull-requests/XXX"

[[features.pending]]
remote = "origin"
name = "currently merging feature"
pr = "https://github/fluendo/git-upstream-workflow/pull-requests/XXX"

[[features.pending]]
remote = "origin"
name = "still pending feature"
status = "pending"
```
